### PR TITLE
adding install-dependencies in the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,11 @@ init:
 	pip install --upgrade pip;
 	pip install --upgrade setuptools wheel twine
 
+install-dependencies:
+	sudo apt install python3-tk;
+	sudo apt install python3-venv;
+	sudo apt install libzbar-dev
+
 install:
 	source env/bin/activate;
 	pip install -e .;


### PR DESCRIPTION
adding a section "install-dependencies" in the Makefile which installs the missing dependencies "python3-tk", "libzbar-dev", "python3-dev". It can be used by running the command "make install-dependencies"