### PR TITLE
Add org_root parameter in CLI commands linked to attributes deidentification

### DIFF
--- a/dpiste/__main__.py
+++ b/dpiste/__main__.py
@@ -306,6 +306,7 @@ def main(a):
   hdh_sftp_parser.add_argument("-l", "--sftp-limit", required=True, help="Free space to leave at any time on the SFTP (in GB)", type=float)
   hdh_sftp_parser.add_argument("-i", "--id-worker", required=False, help="Worker ID (0-n)(default: 0)", default=0, type=int)
   hdh_sftp_parser.add_argument("-w", "--nb-worker", required=False, help="Amount of Workers (default: 1)", default=1, type=int)
+  hdh_sftp_parser.add_argument("-o", "--org-root", required=True, help="Organization root used for building new DICOM UIDs", type=str)
   hdh_sftp_parser.add_argument("-r", "--reset-sftp", required=False, help="Erase all data on the SFTP server", default=False, type=bool)
   hdh_sftp_parser.set_defaults(func = do_send_crypted_hdh)
 
@@ -446,6 +447,7 @@ def do_send_crypted_hdh(args, *other):
     tmp_fol = args.tmp_folder,
     id_worker = args.id_worker,
     nb_worker = args.nb_worker,
+    org_root = args.org_root,
     reset_sftp = args.reset_sftp
     )
 

--- a/dpiste/p08_mammogram_deidentification.py
+++ b/dpiste/p08_mammogram_deidentification.py
@@ -94,7 +94,7 @@ Here is a summary of the DICOMs that have been de-identified.\n\n\n
         )
 
 
-def deid_mammogram2(indir = None, outdir = None):
+def deid_mammogram2(indir = None, outdir = None, org_root):
     """
     Anonymize a complete directory of DICOM.
     @param
@@ -107,20 +107,21 @@ def deid_mammogram2(indir = None, outdir = None):
     if outdir == None:
         outdir = utils.get_home('data', 'output','hdh', '')
 
-    df = deidentify_attributes(indir, outdir)
+    df = deidentify_attributes(indir, outdir, org_root)
     df.to_csv(os.path.join(outdir, 'meta.csv'))
     df2dicom(df, outdir, do_image_deidentification=True)
 
 
-def deidentify_mammograms_hdh(indir: str, outdir: str, sftp: SFTPClient):
-    df = deidentify_attributes(indir, outdir, erase_outdir=False)
+def deidentify_mammograms_hdh(indir: str, outdir: str, sftp: SFTPClient, org_root: str):
+    df = deidentify_attributes(indir, outdir, org_root, erase_outdir=False)
     log('Deidentifying mammograms...')
     df2hdh(df, outdir)
     return
 
 
 def p08_001_export_hdh(sftph: str, sftpu: str, batch_size: int, sftp_limit: float,
-    tmp_fol: str, id_worker: int, nb_worker: int, reset_sftp=False, screening_filter=False, test=False) -> None:
+    tmp_fol: str, id_worker: int, nb_worker: int, org_root: str, reset_sftp=False, screening_filter=False, 
+    test=False) -> None:
     """Gets, deidentifies and sends mammograms to the HDH sftp"""
     indir, outdir = init_local_files(tmp_fol, id_worker)
     worker_indir = os.path.join(indir, str(id_worker))
@@ -177,7 +178,7 @@ def p08_001_export_hdh(sftph: str, sftpu: str, batch_size: int, sftp_limit: floa
         get_dicom(key=study_id, dest=worker_indir, server='10.1.2.9', port=11112,
             title='DCM4CHEE', retrieveLevel='STUDY', silent=True)
 
-        deidentify_mammograms_hdh(worker_indir, study_dir, sftp)
+        deidentify_mammograms_hdh(worker_indir, study_dir, sftp, org_root)
         c, sftp = renew_sftp(sftph, sftpu, sftp, c)
         send2hdh_study_content(study_dir, id_worker, sftp)
         uploaded = 1 if uploaded == 0 else uploaded

--- a/dpiste/tools/evaluate_consistency.py
+++ b/dpiste/tools/evaluate_consistency.py
@@ -63,6 +63,7 @@ def run(folder: str, verbose: True) -> None:
         tmp_fol=get_home('data/input/dcm4chee/consistency_test/'),
         id_worker=0,
         nb_worker=1,
+        org_root="2.25" # Derived DICOM UID Construction method (for tests only)
         reset_sftp=True,
         screening_filter=True,
         test=True


### PR DESCRIPTION
## Context

We removed `org_root` DICOM UID prefix from kskit. It was hardcoded inside the package. In order to maintain reusability, we needed to put this `org_root` as a parameter inside the dpiste package.

## Actions taken

In this branch, we added a new parameter `org_root` for staying up-to-date with `deidentify_attributes()` inside kskit.