### PR TITLE
Corrections brought to add image laterality to processed mammogram attributes

### DIFF
--- a/dpiste/__main__.py
+++ b/dpiste/__main__.py
@@ -280,7 +280,7 @@ def main(a):
   hdh_sftp_parser.add_argument("-i", "--id-worker", required=False, help="Worker ID (0-n)(default: 0)", default=0, type=int)
   hdh_sftp_parser.add_argument("-w", "--nb-worker", required=False, help="Amount of Workers (default: 1)", default=1, type=int)
   hdh_sftp_parser.add_argument("-r", "--reset-sftp", required=False, help="Erase all data on the SFTP server", default=False, type=bool)
-  hdh_sftp_parser.add_argument("-a", "--images-allowed", required=False, help="Include/Excluse mammogram images in the process (default: True)", default=False, action='store_true')
+  hdh_sftp_parser.add_argument("-e", "--exclude-images", required=False, help="Exclude mammogram images of the process and keep only meta files (default: False)", default=False, action='store_true')
   hdh_sftp_parser.add_argument("-p", "--only-positive", required=False, help="Process only positive images (L1L2_positif = True) (default: False)", default=False, action='store_true')
   hdh_sftp_parser.set_defaults(func = do_send_crypted_hdh)
 
@@ -419,7 +419,7 @@ def do_send_crypted_hdh(args, *other):
     id_worker = args.id_worker,
     nb_worker = args.nb_worker,
     reset_sftp = args.reset_sftp,
-    images_allowed = args.images_allowed,
+    exclude_images = args.exclude_images,
     only_positive = args.only_positive
     )
 

--- a/dpiste/__main__.py
+++ b/dpiste/__main__.py
@@ -280,6 +280,8 @@ def main(a):
   hdh_sftp_parser.add_argument("-i", "--id-worker", required=False, help="Worker ID (0-n)(default: 0)", default=0, type=int)
   hdh_sftp_parser.add_argument("-w", "--nb-worker", required=False, help="Amount of Workers (default: 1)", default=1, type=int)
   hdh_sftp_parser.add_argument("-r", "--reset-sftp", required=False, help="Erase all data on the SFTP server", default=False, type=bool)
+  hdh_sftp_parser.add_argument("-a", "--images-allowed", required=False, help="Include/Excluse mammogram images in the process (default: True)", default=False, action='store_true')
+  hdh_sftp_parser.add_argument("-p", "--only-positive", required=False, help="Process only positive images (L1L2_positif = True) (default: False)", default=False, action='store_true')
   hdh_sftp_parser.set_defaults(func = do_send_crypted_hdh)
 
   # -- local-test
@@ -416,7 +418,9 @@ def do_send_crypted_hdh(args, *other):
     tmp_fol = args.tmp_folder,
     id_worker = args.id_worker,
     nb_worker = args.nb_worker,
-    reset_sftp = args.reset_sftp
+    reset_sftp = args.reset_sftp,
+    images_allowed = args.images_allowed,
+    only_positive = args.only_positive
     )
 
 def do_local_pipeline_test(args, *other):

--- a/dpiste/__main__.py
+++ b/dpiste/__main__.py
@@ -282,6 +282,14 @@ def main(a):
   hdh_sftp_parser.add_argument("-r", "--reset-sftp", required=False, help="Erase all data on the SFTP server", default=False, type=bool)
   hdh_sftp_parser.set_defaults(func = do_send_crypted_hdh)
 
+  # -- local-test
+  hdh_sftp_parser = hdhout_subs.add_parser("local-test", help = "Writes mammograms locally to test the pipeline")
+  hdh_sftp_parser.add_argument("-t", "--tmp-folder", required=True, help="Temporary storage before files are send to the sftp", type=str)
+  hdh_sftp_parser.add_argument("-b", "--batch-size", required=False, help="Maximum number of files in the sftp, default = 20", default=20, type=int)
+  hdh_sftp_parser.add_argument("-i", "--id-worker", required=False, help="Worker ID (0-n)(default: 0)", default=0, type=int)
+  hdh_sftp_parser.add_argument("-w", "--nb-worker", required=False, help="Amount of Workers (default: 1)", default=1, type=int)
+  hdh_sftp_parser.set_defaults(func = do_local_pipeline_test)
+
   # -- sftp-status
   hdh_status_sftp_parser = hdhout_subs.add_parser("sftp-status", help = "Shows SFTP info")
   hdh_status_sftp_parser.add_argument("-s", "--server-sftp", required=True, help="Hostname of the hdh dedicated sftp")
@@ -410,6 +418,14 @@ def do_send_crypted_hdh(args, *other):
     nb_worker = args.nb_worker,
     reset_sftp = args.reset_sftp
     )
+
+def do_local_pipeline_test(args, *other):
+  p08_001_export_local(
+    batch_size = args.batch_size,
+    tmp_fol = args.tmp_folder,
+    id_worker =  args.id_worker,
+    nb_worker = args.nb_worker
+  )
 
 def do_show_status_hdh(args, *other):
   p08_002_status_hdh(

--- a/dpiste/p06_mammogram_extraction.py
+++ b/dpiste/p06_mammogram_extraction.py
@@ -84,6 +84,10 @@ def apply_filter(df: pd.DataFrame, field: str = None, value: str = None) -> pd.D
   elif field == 'GET_ACR5':
     df = get_acr5(df)
     return df[pd.notna(df['DICOM_Studies'])]
+  elif field == 'GET_POSITIVE_WITH_IMG_ONLY':
+    df = get_positive_studies_only(df)
+    df = keep_only_studies_with_images(df)
+    return df[pd.notna(df['DICOM_Studies'])]
   elif value == 'True':
     return df[(df[field] == True) & (pd.notna(df['DICOM_Studies']))]
   elif value == 'False':
@@ -168,7 +172,7 @@ def filter_depistage_pseudo(df: pd.DataFrame) -> pd.DataFrame:
         pandas.DataFrame: DataFrame with NaN studies removed and only studies where the date 
         equals the value in the 'Date_Mammo' column.
     """
-    df = df[pd.notna(df['DICOM_Studies'])]
+    df = df[pd.notna(df['DICOM_Studies'])].copy()
     df["DICOM_Study"] = df.apply(lambda row: get_dicom(row), axis=1)
     return df
 

--- a/dpiste/p08_mammogram_deidentification.py
+++ b/dpiste/p08_mammogram_deidentification.py
@@ -5,7 +5,13 @@ import time
 
 from dpiste import utils
 from dpiste.dal.screening import depistage_pseudo
-from dpiste.p06_mammogram_extraction import get_acr5
+from dpiste.p06_mammogram_extraction import (
+    get_acr5,
+    get_positive_studies_only,
+    filter_depistage_pseudo,
+    keep_only_studies_with_images,
+    calculate_l1_l2_result,
+)
 from dpiste.p11_hdh_data_transfer import *
 from dpiste.p11_hdh_encryption import p11_001_generate_transfer_keys
 
@@ -112,15 +118,16 @@ def deid_mammogram2(indir = None, outdir = None):
     df2dicom(df, outdir, do_image_deidentification=True)
 
 
-def deidentify_mammograms_hdh(indir: str, outdir: str, sftp: SFTPClient):
+def deidentify_mammograms_hdh(indir: str, outdir: str, sftp: SFTPClient, images_allowed: bool=True):
     df = deidentify_attributes(indir, outdir, erase_outdir=False)
     log('Deidentifying mammograms...')
-    df2hdh(df, outdir)
+    df2hdh(df, outdir, images_allowed)
     return
 
 
 def p08_001_export_hdh(sftph: str, sftpu: str, batch_size: int, sftp_limit: float,
-    tmp_fol: str, id_worker: int, nb_worker: int, reset_sftp=False, screening_filter=False, test=False) -> None:
+    tmp_fol: str, id_worker: int, nb_worker: int, reset_sftp=False, screening_filter=False, 
+    test=False, images_allowed=True, only_positive=False) -> None:
     """Gets, deidentifies and sends mammograms to the HDH sftp"""
     indir, outdir = init_local_files(tmp_fol, id_worker)
     worker_indir = os.path.join(indir, str(id_worker))
@@ -133,6 +140,13 @@ def p08_001_export_hdh(sftph: str, sftpu: str, batch_size: int, sftp_limit: floa
         utils.sftp_reset(sftp)
     df = depistage_pseudo()
     df = filter_screening(df) if screening_filter else df
+    
+    if only_positive:
+        df_with_study_id = filter_depistage_pseudo(df)
+        df_with_study_id_and_lecture_results = calculate_l1_l2_result(df_with_study_id)
+        df_with_positive_only = get_positive_studies_only(df_with_study_id_and_lecture_results)
+        df = keep_only_studies_with_images(df_with_positive_only)
+
     studies = build_studies(df, date_mammo_only=True) if screening_filter else build_studies(df)
     total2upload = len(studies.index)
     deid_studies = deidentify_study_id(studies.copy())
@@ -177,7 +191,7 @@ def p08_001_export_hdh(sftph: str, sftpu: str, batch_size: int, sftp_limit: floa
         get_dicom(key=study_id, dest=worker_indir, server='10.1.2.9', port=11112,
             title='DCM4CHEE', retrieveLevel='STUDY', silent=True)
 
-        deidentify_mammograms_hdh(worker_indir, study_dir, sftp)
+        deidentify_mammograms_hdh(worker_indir, study_dir, sftp, images_allowed=images_allowed)
         c, sftp = renew_sftp(sftph, sftpu, sftp, c)
         send2hdh_study_content(study_dir, id_worker, sftp)
         uploaded = 1 if uploaded == 0 else uploaded

--- a/dpiste/p08_mammogram_deidentification.py
+++ b/dpiste/p08_mammogram_deidentification.py
@@ -195,6 +195,61 @@ def p08_001_export_hdh(sftph: str, sftpu: str, batch_size: int, sftp_limit: floa
     return
 
 
+def p08_001_export_local(batch_size: int, tmp_fol: str, id_worker: int, nb_worker: int, screening_filter=False) -> None:
+    """Gets, deidentifies and writes mammograms locally"""
+    indir, outdir = init_local_files(tmp_fol, id_worker)
+    worker_indir = os.path.join(indir, str(id_worker))
+    worker_outdir = os.path.join(outdir, str(id_worker))
+    final_dir = os.path.join(tmp_fol, "final")
+    
+    df = depistage_pseudo()
+    df = filter_screening(df) if screening_filter else df
+    studies = build_studies(df, date_mammo_only=True) if screening_filter else build_studies(df)
+    total2upload = len(studies.index)
+    deid_studies = deidentify_study_id(studies.copy())
+    
+    utils.reset_local_files(worker_indir)
+    if id_worker == 0:
+        deid_studies.to_csv(os.path.join(final_dir, 'studies.csv'))
+        df.drop(columns='DICOM_Studies').to_csv(os.path.join(final_dir, 'screening.csv'))
+    
+    progress = 0
+    count = 0
+    log(f'Words ignored by OCR: {load_authorized_words()}')
+    for index in studies.index[:10]:
+        study_id = studies['study_id'][index]
+        study_hash = int(hashlib.sha512(study_id.encode('utf-8')).hexdigest(), 16)
+        if abs(study_hash) % nb_worker == id_worker:
+            count += 1
+        if progress >= count or \
+            abs(study_hash) % nb_worker != id_worker:
+            continue
+
+        id_random = studies['id_random'][index]
+        deid_study_id = gen_dicom_uid(id_random, study_id)
+
+        study_dir = os.path.join(worker_outdir, deid_study_id)
+        worker_studies = os.listdir(os.path.join(worker_outdir))
+        os.mkdir(study_dir) if deid_study_id not in worker_studies else None
+
+        log(f'Getting study n°{study_id}')
+        get_dicom(key=study_id, dest=worker_indir, server='10.1.2.9', port=11112,
+            title='DCM4CHEE', retrieveLevel='STUDY', silent=True)
+
+        deidentify_mammograms_hdh(worker_indir, study_dir, None)
+        move_all_files_to_final(worker_outdir, study_dir, final_dir)
+        utils.cleandir(worker_indir)
+        utils.cleandir(worker_outdir)
+    log('All done!')
+    return
+
+def move_all_files_to_final(worker_outdir: str, study_dir: str, final_dir: str) -> None:
+    final_study_dir = os.path.join(final_dir, os.path.basename(study_dir))
+    os.mkdir(final_study_dir)
+    for file in os.listdir(study_dir):
+        os.rename(os.path.join(study_dir, file), os.path.join(final_study_dir, file))
+
+
 def p08_002_status_hdh(sftph: str, sftpu: str, nb_worker: int) -> None:
     tmp_folder = utils.get_home('reports', '')
     progress_folder = os.path.join(tmp_folder, 'progress')
@@ -302,4 +357,3 @@ def filter_screening(df: pd.DataFrame) -> pd.DataFrame:
     df_acr5 = get_acr5(df_without_na)
     df_acr5_age = df_acr5[df_acr5['Age_Mammo'] == 69]
     return df_acr5_age
-

--- a/dpiste/p08_mammogram_deidentification.py
+++ b/dpiste/p08_mammogram_deidentification.py
@@ -118,16 +118,16 @@ def deid_mammogram2(indir = None, outdir = None):
     df2dicom(df, outdir, do_image_deidentification=True)
 
 
-def deidentify_mammograms_hdh(indir: str, outdir: str, sftp: SFTPClient, images_allowed: bool=True):
+def deidentify_mammograms_hdh(indir: str, outdir: str, sftp: SFTPClient, exclude_images: bool=False):
     df = deidentify_attributes(indir, outdir, erase_outdir=False)
     log('Deidentifying mammograms...')
-    df2hdh(df, outdir, images_allowed)
+    df2hdh(df, outdir, exclude_images)
     return
 
 
 def p08_001_export_hdh(sftph: str, sftpu: str, batch_size: int, sftp_limit: float,
     tmp_fol: str, id_worker: int, nb_worker: int, reset_sftp=False, screening_filter=False, 
-    test=False, images_allowed=True, only_positive=False) -> None:
+    test=False, exclude_images=False, only_positive=False) -> None:
     """Gets, deidentifies and sends mammograms to the HDH sftp"""
     indir, outdir = init_local_files(tmp_fol, id_worker)
     worker_indir = os.path.join(indir, str(id_worker))
@@ -191,7 +191,7 @@ def p08_001_export_hdh(sftph: str, sftpu: str, batch_size: int, sftp_limit: floa
         get_dicom(key=study_id, dest=worker_indir, server='10.1.2.9', port=11112,
             title='DCM4CHEE', retrieveLevel='STUDY', silent=True)
 
-        deidentify_mammograms_hdh(worker_indir, study_dir, sftp, images_allowed=images_allowed)
+        deidentify_mammograms_hdh(worker_indir, study_dir, sftp, exclude_images=exclude_images)
         c, sftp = renew_sftp(sftph, sftpu, sftp, c)
         send2hdh_study_content(study_dir, id_worker, sftp)
         uploaded = 1 if uploaded == 0 else uploaded

--- a/dpiste/p11_hdh_data_transfer.py
+++ b/dpiste/p11_hdh_data_transfer.py
@@ -146,7 +146,6 @@ def send2hdh_df(df: pd.DataFrame, outdir: str, filename: str,
     df.to_csv(filepath)
     p11_encrypt_hdh(filepath, encrypted_filepath, rmold=True)
     sftp_fpath = os.path.join(OK_DIRNAME, os.path.basename(encrypted_filepath))
-    print(sftp_fpath)
     sftp.put(encrypted_filepath, sftp_fpath)
     return
 

--- a/dpiste/tools/data_integrity.py
+++ b/dpiste/tools/data_integrity.py
@@ -1,0 +1,19 @@
+import os
+import pandas as pd
+
+root_path = "/space/Work/william2/deep.piste/home/data/local_test/final"
+studies_df_path = os.path.join(root_path, "studies.csv")
+
+studies_df = pd.read_csv(studies_df_path)
+
+matching_studies, total = 0, 0
+for file in os.listdir(root_path):
+    if not os.path.isdir(os.path.join(root_path, file)):
+        continue
+    
+    study_id = file
+    total += 1
+    if len(studies_df[studies_df["study_pseudo_id"] == study_id]) != 0:
+        matching_studies += 1
+
+print(f"{matching_studies}/{total}")

--- a/dpiste/tools/patch_extraction.py
+++ b/dpiste/tools/patch_extraction.py
@@ -1,7 +1,13 @@
 
 from dpiste.dal.screening import depistage_pseudo
 from dpiste.p08_mammogram_deidentification import build_studies
-from dpiste.utils import cleandir
+from dpiste.p06_mammogram_extraction import (
+    get_positive_studies_only,
+    filter_depistage_pseudo,
+    keep_only_studies_with_images,
+    calculate_l1_l2_result,
+)
+from dpiste.utils import cleandir, get_home
 
 from kskit.dicom.get_dicom import get_dicom
 from kskit.dicom.utils import log
@@ -14,8 +20,48 @@ import time
 import pandas as pd
 import subprocess
 
-ACR5_STUDIES_DIR = "/space/Work/william2/deep.piste/home/data/input/dcm4chee/dicom_acr5" 
-PATCH_EXTRACT_DIR = "/space/Work/william2/deep.piste/home/data/patch_extraction"
+POSITIVE_STUDY_DIR = "/space/Work/william2/deep.piste/home/input/dcm4chee/dicom_positive" 
+PATCH_EXTRACT_DIR = "/space/Work/william2/deep.piste/home/input/dcm4chee/patch_extraction"
+
+
+def extract_positive_studies_and_build_meta_patch(server="10.1.2.9", port=11112, title="DCM4CHEE", retrieveLevel="STUDY"):
+  # Screening Filtering
+  meta_patch_file = os.path.join(get_home('input', 'dcm4chee'), 'meta-patch.csv')
+  df = depistage_pseudo()
+
+  df_with_study_id = filter_depistage_pseudo(df)
+  df_with_study_id_and_lecture_results = calculate_l1_l2_result(df_with_study_id)
+  df_with_positive_only = get_positive_studies_only(df_with_study_id_and_lecture_results)
+  studies = keep_only_studies_with_images(df_with_positive_only)
+
+  # Init or Retrieve Meta Patch
+  if not os.path.isfile(meta_patch_file):
+    cleandir(get_home('input', 'dcm4chee', 'dicom_positive'))
+    meta_patch = pd.DataFrame([], columns=['IdRandom', 'DeidentifiedStudyUID', 'DeidentifiedSOPInstanceUID', 'ViewCodeSequence-CodeValue', 'ImageLaterality'])
+  else:
+    meta_patch = pd.read_csv(meta_patch_file)
+
+  for progress, study_id in enumerate(studies["DICOM_Study"]):
+    if gen_dicom_uid('', study_id) in meta_patch['DeidentifiedStudyUID']:
+      continue
+
+    study_dir = get_home('input', 'dcm4chee', 'dicom_positive', study_id)
+    try:
+      os.mkdir(study_dir)
+    except FileExistsError:
+      cleandir(study_dir)
+
+    # Study Extraction 
+    get_dicom(key=study_id, dest=study_dir, server=server, port=port, title=title, retrieveLevel=retrieveLevel, silent=True)
+
+    # Meta Patch Update
+    study_row = studies[studies["DICOM_Study"] == study_id]["id_random"].tolist()
+    meta_patch = add_study_to_meta_patch(study_dir, meta_patch, studies[studies["DICOM_Study"] == study_id]["id_random"].tolist()[0])
+    meta_patch.to_csv(meta_patch_file) if progress % 10 == 0 else None
+    
+    cleandir(study_dir)
+    print(f"{progress + 1}/{len(studies)} queried")
+
 
 def get_studies_and_patch_meta_files():
     df = depistage_pseudo()
@@ -28,20 +74,26 @@ def get_studies_and_patch_meta_files():
         'ImageLaterality',
         ]
     )
-    p1 = subprocess.Popen(["ls", ACR5_STUDIES_DIR], stdout=subprocess.PIPE)
+    p1 = subprocess.Popen(["ls", POSITIVE_STUDY_DIR], stdout=subprocess.PIPE)
     p2 = subprocess.Popen(["wc", "-l"], stdin=p1.stdout, stdout=subprocess.PIPE)
     p1.stdout.close()
     mammograms_number = p2.communicate()[0].decode('utf8')
 
     nb_mammogram_retrieved = 0
-    for root, dirs, files in os.walk(ACR5_STUDIES_DIR):
+    for root, dirs, files in os.walk(POSITIVE_STUDY_DIR):
         for study_dir in dirs:
             study_id = study_dir
             study_dir = os.path.join(root, study_dir)
+            study_row = studies[studies["study_id"] == study_id]["id_random"].tolist()
+            if len(study_row) > 1:
+                print(f"Warning: study {study_id} has more than 1 row in df")
+            elif len(study_row) == 0:
+                print(f"Warning: study {study_id} has no row in df")
+                continue
             meta_patch = add_study_to_meta_patch(study_dir, meta_patch, studies[studies["study_id"] == study_id]["id_random"].tolist()[0])
             nb_mammogram_retrieved += 1
             print(f"{nb_mammogram_retrieved}/{mammograms_number}")
-    print(meta_patch.columns)
+
     meta_patch.to_csv(os.path.join(PATCH_EXTRACT_DIR, "meta-patch.csv"), index=False)
     print(f"Meta Patch has been written at {PATCH_EXTRACT_DIR}")
 
@@ -51,11 +103,13 @@ def add_study_to_meta_patch(study_dir, meta_df, id_random):
     for dcm_file in os.listdir(study_dir):
         dcm_filepath = os.path.join(study_dir, dcm_file)
         ds = pydicom.dcmread(dcm_filepath)
+        study_id = get_deidentified_study_id(os.path.basename(study_dir))
         dicom_uid = get_deidentified_dicom_id(ds)
         orientation = get_dicom_orientation(ds)
-        new_row = pd.DataFrame.from_dict({**id_random, **dicom_uid, **orientation})
+        new_row = pd.DataFrame.from_dict({**id_random, **study_id, **dicom_uid, **orientation})
         meta_df = pd.concat([meta_df, new_row], ignore_index=True)
     return meta_df
+
 
 def get_dicom_orientation(ds):
     if "ViewCodeSequence" not in ds:
@@ -73,9 +127,14 @@ def get_dicom_orientation(ds):
     }
 
 
+def get_deidentified_study_id(study_id):
+    study_id = gen_dicom_uid('', study_id)
+    return { "DeidentifiedStudyUID": [study_id] }
+
+
 def get_deidentified_dicom_id(ds):
     dicom_id = gen_dicom_uid('', ds["SOPInstanceUID"].value)
-    return { "SOPInstanceUID": [dicom_id] }
+    return { "DeidentifiedSOPInstanceUID": [dicom_id] }
 
 
 def deidentify_study_id(studies: pd.DataFrame) -> pd.DataFrame:
@@ -87,8 +146,7 @@ def deidentify_study_id(studies: pd.DataFrame) -> pd.DataFrame:
     studies = studies.rename(columns={'study_id': 'study_pseudo_id'})
     return studies
 
+
 if __name__ == '__main__':
-    #add_view_code_sequence_to_meta("/space/Work/william2/deep.piste/home/data/input/dcm4chee/dicom_positive/1.2.826.0.1.3680043.2.455.30.10.762000.1710.707536")
-    #get_studies_and_patch_meta_files()
-    get_studies_and_patch_meta_files()
+    extract_positive_studies_and_build_meta_patch()
     

--- a/worker0_progress.json
+++ b/worker0_progress.json
@@ -1,0 +1,1 @@
+{"uploaded": 3, "total": 8208}

--- a/worker0_progress.json
+++ b/worker0_progress.json
@@ -1,1 +1,0 @@
-{"uploaded": 3, "total": 8208}


### PR DESCRIPTION
## Context

We needed to do another run of the data transfer pipeline for adding missing information (image laterality).

## Actions taken

- Add a command for launching the deep.piste/hdh pipeline completely in local (test purposes)
- Add a parameter to CLI for excluding image deidentification of the transfer in order to save time
- Add a parameter to CLI for getting only mammograms associated to positive studies
- Add scripts for executing the patch correction inside `dpiste/tools/`